### PR TITLE
register napmiditwister

### DIFF
--- a/modules/napmiditwister.json
+++ b/modules/napmiditwister.json
@@ -1,0 +1,21 @@
+{
+  "name": "napmiditwister",
+  "categories":
+  [
+    "midi"
+  ],
+  "platforms":
+  [
+    "windows",
+    "linux",
+    "macOS"
+  ],
+  "author":
+  {
+    "name": "Lesley van Hoek",
+    "link": "https://lesleyvanhoek.nl/"
+  },
+  "description": "Utility that lets you map the encoders of the Midi Fighter Twister to NAP parameters",
+  "link": "https://github.com/lshoek/napmiditwister",
+  "visible": true
+}

--- a/modules/napmiditwister.json
+++ b/modules/napmiditwister.json
@@ -16,6 +16,7 @@
     "link": "https://lesleyvanhoek.nl/"
   },
   "description": "Utility that lets you map the encoders of the Midi Fighter Twister to NAP parameters",
+  "image": "https://raw.githubusercontent.com/lshoek/napmiditwister/main/midifightertwister.webp",
   "link": "https://github.com/lshoek/napmiditwister",
   "visible": true
 }


### PR DESCRIPTION
Utility that lets you map the encoders of the Midi Fighter Twister to NAP parameters