### PR TITLE
Register napfft

### DIFF
--- a/modules/napfft.json
+++ b/modules/napfft.json
@@ -1,0 +1,20 @@
+{
+  "name": "napfft",
+  "categories":
+  [
+    "fft",
+    "audio"
+  ],
+  "platforms":
+  [
+    "windows"
+  ],
+  "author":
+  {
+    "name": "Lesley van Hoek",
+    "link": "https://lesleyvanhoek.nl/"
+  },
+  "description": "Module that wraps Kiss FFT functionality for NAP 0.6",
+  "link": "https://github.com/lshoek/napfft",
+  "visible": true
+}


### PR DESCRIPTION
Module that wraps [Kiss FFT](https://github.com/mborgerding/kissfft) functionality for NAP 0.6. Contributions are welcome!

- Implements real-optimized FFTs (positive half-spectrum: `nfft/2+1` complex frequency bins)
- Currently supports Windows only
