### PR TITLE
added naplua module

### DIFF
--- a/modules/naplua.json
+++ b/modules/naplua.json
@@ -13,7 +13,7 @@
     "name": "Casimir Geelhoed",
     "link": "https://github.com/CasimirGeelhoed"
   },
-  "description": "Adds Lua scripting to NAP",
+  "description": "Adds Lua scripting functionality to NAP",
   "link": "https://github.com/CasimirGeelhoed/naplua",
   "visible": true
 }

--- a/modules/naplua.json
+++ b/modules/naplua.json
@@ -1,0 +1,19 @@
+{
+  "name": "naplua",
+  "categories":
+  [
+    "scripting"
+  ],
+  "platforms":
+  [
+    "macos"
+  ],
+  "author":
+  {
+    "name": "Casimir Geelhoed",
+    "link": "https://github.com/CasimirGeelhoed"
+  },
+  "description": "Adds Lua scripting to NAP",
+  "link": "https://github.com/CasimirGeelhoed/naplua",
+  "visible": true
+}


### PR DESCRIPTION
This is a NAP module that embeds a [Lua](https://www.lua.org/) script as a NAP resource using [LuaBridge3](https://github.com/kunitoki/LuaBridge3). Each LuaScript resource manages a distinct LuaState, to which C++ functions and types can be exposed and from which variables can be read and functions can be called. It works great with real-time editing.

For more information, see the [repository](http://www.github.com/CasimirGeelhoed/naplua).

![demovid2trimmed copy 4](https://github.com/user-attachments/assets/dd389c94-c463-40f6-a9aa-6b0f9ad76e19)
